### PR TITLE
Convert for use with Cygwin (DO NOT MERGE)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,25 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        gap-branch:
-          - master
-        ABI: ['']
-        GAP_PKGS_TO_BUILD:
-          - ''
-          - 'default'
-        HPCGAP: ['no']
         include:
-          - os: ubuntu-latest
-            gap-branch: master
-            GAP_PKGS_TO_BUILD: ''
-            HPCGAP: yes
-          - os: ubuntu-latest
-            gap-branch: master
-            ABI: 32
-            GAP_PKGS_TO_BUILD: 'default'
-            HPCGAP: no
-          - os: macos-latest
+          - os: windows-latest
+            ABI: ''
             gap-branch: master
             GAP_PKGS_TO_BUILD: ''
             HPCGAP: no

--- a/action.yml
+++ b/action.yml
@@ -59,21 +59,21 @@ runs:
             fi
             brew install gmp zlib && brew link zlib
           fi
-        shell: bash
+        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
 
         # pkg-ci-scripts is not used by this Action, but currently the other
         # gap-actions Actions still assume that this Action has installed it.
         # This step should therefore be removed eventually
       - name: "Download CI scripts"
-        shell: bash
+        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
         run: git clone https://github.com/gap-system/pkg-ci-scripts.git
 
       - name: "Clone GAP"
-        shell: bash
+        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
         run: git clone --depth=2 -b ${{ inputs.GAPBRANCH }} https://github.com/gap-system/gap.git $HOME/gap
 
       - name: "Build GAP and download packages"
-        shell: bash
+        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
         env:
           ABI: ${{ inputs.ABI }}
         run: |
@@ -96,7 +96,7 @@ runs:
           make bootstrap-pkg-${{ inputs.GAP_BOOTSTRAP }} DOWNLOAD="$WGET" WGET="$WGET"
           
       - name: "Clone additional GAP packages"
-        shell: bash
+        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
         run: |
           # optionally: clone specific package versions, in case we need to test
           # with development versions
@@ -121,7 +121,7 @@ runs:
           done
           
       - name: "Build additional GAP packages"
-        shell:  bash
+        shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
         env:
           ABI: ${{ inputs.ABI }}
         run: |


### PR DESCRIPTION
The purpose of this PR is to show how it is possible to have a version of this that works with the Cygwin provided by https://github.com/gap-actions/setup-cygwin-for-gap – see #18. This branch is currently being used in https://github.com/gap-packages/io/pull/97 - so you can see how it works (or rather doesn't work) there.

(Note that this is based on the older version of this action that also built the package as well as GAP.)

Some of the steps are the same and can use `bash` as the shell (downloading the CI scripts). Some of the steps I have only got to work with the `cmd` shell. 

I haven't checked, but I imagine that these steps are not currently passing on the appropriate environment variables to `C:\cygwin64\bin\bash`.

I don't yet understand this stuff well enough to see how this could be unified with the version that runs on Ubuntu/macOS.