### PR TITLE
Stop cloning pkg-ci-scripts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,13 +59,6 @@ runs:
           fi
         shell: bash
 
-        # pkg-ci-scripts is not used by this Action, but currently the other
-        # gap-actions Actions still assume that this Action has installed it.
-        # This step should therefore be removed eventually
-      - name: "Download CI scripts"
-        shell: bash
-        run: git clone https://github.com/gap-system/pkg-ci-scripts.git
-
       - name: "Clone GAP"
         shell: bash
         run: git clone --depth=2 -b ${{ inputs.GAPBRANCH }} https://github.com/gap-system/gap.git $HOME/gap


### PR DESCRIPTION
Resolves #25 -- but should only be merged once all the PRs referenced therein are merged, i.e. once none of our actions uses it anymore. (Perhaps wait even longer until all the actions other than `setup-gap` even have a tagged commit with the change)