### PR TITLE
Enabling work to support a Cygwin branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,9 @@ on:
   - push
   - pull_request
 
+env:
+  CHERE_INVOKING: 1
+
 jobs:
   test:
     name: ${{ matrix.gap-branch }} ${{ matrix.ABI }} - Packages ${{ matrix.GAP_PKGS_TO_BUILD }} - HPCGAP ${{ matrix.HPCGAP }} - ${{ matrix.os }}
@@ -39,6 +42,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - if: ${{ matrix.os == 'windows-latest' }}
+        uses: gap-actions/setup-cygwin@v1
       - uses: ./
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ inputs:
     description: 'make bootstrap-pkg-? (i.e. full/minimal)'
     required: false
     default: 'full'
+env:
+  CHERE_INVOKING: 1
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
These additions are irrelevant for the existing Unix stuff.

However, including these changes in the master branch of the repository means that there will be fewer diffs to the future Cygwin branch that I'm working on, and so there will hopefully fewer conflicts in the future when changes are made to the master branch that should be integrated into the Cygwin branch.