### PR TITLE
Attempt to fix Issue #38

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,7 @@ runs:
           for pkg in ${{ inputs.GAP_PKGS_TO_CLONE }}; do
               # delete any existing variants of the package to avoid multiple versions
               # from being compiled later on
-              rm -rf "$pkg"*
+              rm -rf "${pkg##*/}"*
               if [[ "$pkg" =~ ^http ]] ; then
                   # looks like a full URL
                   git clone "$pkg"


### PR DESCRIPTION
I don't really know if this fixes the issue or not, but it changes for example `digraphs/digraphs` to `digraphs` and deletes all instances of `digraphs`. Happy to amend as necessary!
