### PR TITLE
Look for package names in a case-insensitive way

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,7 @@ runs:
         run: |
           # build some packages
           BuildPackagesOptions="--strict"
+          shopt -s nocaseglob
           cd $HOME/gap/pkg
           for pkg in ${{inputs.GAP_PKGS_TO_BUILD}}; do
               ../bin/BuildPackages.sh ${BuildPackagesOptions} $pkg*


### PR DESCRIPTION
In GAP 4.11 and earlier, packages were often mixed case, in 4.12 they are always lower case.

This looks for packages case-insensitively, so they can be found in all versions of GAP.