### PR TITLE
Towards v3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Setup Cygwin"
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: stertooy/setup-cygwin@official-action-and-batch
+        uses: gap-actions/setup-cygwin@v2
         
       - name: "Setup GAP"
         uses: ./

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,8 @@ jobs:
           - os: windows-latest
             configflags: '--with-gmp=builtin'
           - os: macos-latest
+            gap-version: stable-4.12
+          - os: macos-latest
             gap-version: v4.10
           - os: macos-latest
             gap-version: v4.11.1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,18 +15,23 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         gap-version:
-          - "4.10"
+          - v4.10
           - v4.11.1
-          - 4.12.0
-          - v4.13.0-alpha2
-          - v4
-          - latest
-          - stable-4.10
           - stable-4.12
-          - stable-4.14
+          - v4.13.0-alpha2
+          - 4
+          - latest
           - default
           - v4.15dev
-        configflags: ['--with-gmp=system', '--with-gmp=builtin']
+        configflags: ['', '--with-gmp=builtin']
+        exclude:
+          - os: windows-latest
+            configflags: '--with-gmp=builtin'
+          - os: macos-latest
+            gap-version: v4.10
+          - os: macos-latest
+            gap-version: v4.11.1
+            configflags: '--with-gmp=builtin'
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,53 +1,58 @@
 name: CI
 
-# Trigger the workflow on push or pull request
 on:
   push:
-    branches:
-      - master
-      - cygwin*
   pull_request:
-
-env:
-  CHERE_INVOKING: 1
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:
-    name: ${{ matrix.gap-branch }} ${{ matrix.ABI }} - Packages ${{ matrix.GAP_PKGS_TO_BUILD }} - HPCGAP ${{ matrix.HPCGAP }} - ${{ matrix.os }}
+    name: ${{ matrix.gap-version }} on ${{ matrix.os }} with ${{ matrix.configflags }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        gap-branch:
-          - master
-        ABI: ['']
-        GAP_PKGS_TO_BUILD:
-          - ''
-          - 'default'
-        HPCGAP: ['no']
-        include:
-          - os: ubuntu-latest
-            gap-branch: master
-            GAP_PKGS_TO_BUILD: ''
-            HPCGAP: yes
-          - os: ubuntu-latest
-            gap-branch: master
-            ABI: 32
-            GAP_PKGS_TO_BUILD: 'default'
-            HPCGAP: no
-          - os: macos-latest
-            gap-branch: master
-            GAP_PKGS_TO_BUILD: ''
-            HPCGAP: no
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        gap-version:
+          - "4.10"
+          - v4.11.1
+          - 4.12.0
+          - v4.13.0-alpha2
+          - v4
+          - latest
+          - stable-4.10
+          - stable-4.12
+          - stable-4.14
+          - default
+          - v4.15dev
+        configflags: ['--with-gmp=system', '--with-gmp=builtin']
 
     steps:
-      - uses: actions/checkout@v4
-      - if: ${{ matrix.os == 'windows-latest' }}
-        uses: gap-actions/setup-cygwin@v1
-      - uses: ./
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Setup Cygwin"
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: stertooy/setup-cygwin@official-action-and-batch
+        
+      - name: "Setup GAP"
+        uses: ./
         with:
-          GAPBRANCH: ${{ matrix.gap-branch }}
-          ABI: ${{ matrix.ABI }}
-          GAP_PKGS_TO_BUILD: ${{ matrix.GAP_PKGS_TO_BUILD }}
-          HPCGAP: ${{ matrix.HPCGAP }}
+          gap-version: ${{ matrix.gap-version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          configflags: ${{ matrix.configflags }}
+
+      - name: "Check if GAP can run"
+        shell: bash
+        run: |
+          gap -A --quitonbreak <<GAPINPUT
+            quit;
+          GAPINPUT
+
+      - name: "Check ENV for GAPROOT"
+        shell: bash
+        run: |
+          if [[ -z "$GAPROOT" ]] ; then
+            exit 1
+          fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,9 +55,9 @@ jobs:
             quit;
           GAPINPUT
 
-      - name: "Check ENV for GAPROOT"
+      - name: "Check ENV for GAPROOT and GAP variables"
         shell: bash
         run: |
-          if [[ -z "$GAPROOT" ]] ; then
+          if [[ -z "$GAPROOT" || -z "$GAP" ]] ; then
             exit 1
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,6 @@ jobs:
         uses: ./
         with:
           gap-version: ${{ matrix.gap-version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
           configflags: ${{ matrix.configflags }}
 
       - name: "Check if GAP can run"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,10 +19,11 @@ jobs:
           - v4.11.1
           - stable-4.12
           - v4.13.0-alpha2
+          - 4.15.0-beta1
           - 4
           - latest
           - default
-          - v4.15dev
+          - v4.16dev
         configflags: ['', '--with-gmp=builtin']
         exclude:
           - os: windows-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,7 @@ jobs:
       - name: "Check if GAP can run"
         shell: bash
         run: |
-          gap -A --quitonbreak <<GAPINPUT
+          gap -A <<GAPINPUT
             quit;
           GAPINPUT
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ you will have to change the inputs accordingly. We also recommend replacing bran
  - The `GAPBRANCH` input has been replaced by `gap-version`, which accepts the following input types:
    - `latest`: this will use the latest release of GAP. This will **not** point to the latest pre-release if it is more recent
      than the latest release.
-   - version numbers: e.g. `v4.14.0`, `v4.15.0-beta1`, etc. The leading `v` is optional.
+   - version numbers: e.g. `v4.14.0`, `v4.15.0-beta1`, etc. The leading `v` is optional, the oldest available release is `v4.10.0`.
    - incomplete version numbers: e.g. `v4`, `v4.10`, etc. These will be expanded to the most recent release starting with the incomplete
      version number, e.g. `v4.10` is equivalent to `v4.10.2`. This will **not** expand to pre-releases, and again the leading `v` is
      optional.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# setup-gap V3
+# setup-gap v3
 
 This GitHub action downloads and prepares an instance of GAP.
 It is intended to be used by the Continuous Integration (CI) action of a GAP

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ All of the following inputs are optional.
 - `gpk-pkgs-to-build`:
    - A space-separated list of the GAP packages to build.
    - default: `'io json profiling'`
-- `token`:
-   - Token to authenticate with the GitHub API. You should set this to `${{ secrets.GITHUB_TOKEN }}` in your workflow.
 
 ## Contact
 Please submit bug reports, suggestions for improvements and patches via

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All of the following inputs are optional.
 
 ### What's new in v3
 Version v3 contains many changes compared to version v2. When replacing `setup-gap@v2` by `setup-gap@v3` in an existing workflow,
-you will have to change the inputs accordingly. We also recommend replacing branches be releases, e.g. `stable-v4.14` by `v4.14`.
+you will have to change the inputs accordingly. We also recommend replacing branches by releases, e.g. `stable-v4.14` by `v4.14`.
 
 #### Changes to inputs:
  - The `GAPBRANCH` input has been replaced by `gap-version`, which accepts the following input types:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ will almost surely not work.
 #### Changes to functionality:
  - There is no longer a separate branch for running this action on Windows. This action should work on Windows, assuming it is
    preceded by version v2 or later of [setup-cygwin](https://github.com/gap-actions/setup-gap).
- - The installation location of GAP is added to the variable `GAPROOT`, which can be used in subsequent steps in the workflow.
+ - The installation location of GAP is stored in the environment variable `GAPROOT`, which can be used in subsequent steps in the workflow.
  - The GAP executable is added to `PATH`, thus GAP can now always be started by calling `gap`.
 
 ### Example
@@ -76,6 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: gap-actions/setup-gap@v3
+      # ... additional steps using GAP will usually follow here
 ```
 
 A more extensive example:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,61 @@ will almost surely not work.
    preceded by version v2 or later of [setup-cygwin](https://github.com/gap-actions/setup-gap).
  - The installation location of GAP is added to the variable `GAPROOT`, which can be used in subsequent steps in the workflow.
  - The GAP executable is added to `PATH`, thus GAP can now always be started by calling `gap`.
- 
+
+### Example
+
+The following is a minimal example to run this action.
+
+```yaml
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  # The CI test job
+  test:
+    name: CI test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: gap-actions/setup-gap@v3
+```
+
+A more extensive example:
+
+```yaml
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  # The CI test job
+  test:
+    name: CI test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        gap-version:
+          - latest
+          - v4.15.0-beta1
+          - master
+
+    steps:
+      - uses: gap-actions/setup-cygwin@v2
+        if: ${{ matrix.os == 'windows-latest' }}
+      - uses: actions/checkout@v5
+      - uses: gap-actions/setup-gap@v3
+        with:
+          gap-version: ${{ matrix.gap-version }}
+```
+
 ## Contact
 Please submit bug reports, suggestions for improvements and patches via
 the [issue tracker](https://github.com/gap-actions/setup-gap/issues).

--- a/README.md
+++ b/README.md
@@ -32,10 +32,30 @@ All of the following inputs are optional.
 - `configflags`:
    - Arguments to pass to the GAP configure script.
    - default: `''`
-- `gpk-pkgs-to-build`:
+- `gap-pkgs-to-build`:
    - A space-separated list of the GAP packages to build.
    - default: `'io json profiling'`
 
+### What's new in v3
+Version v3 contains many changes compared to version v2. Simply replacing `setup-gap@v2` by `setup-gap@v3` in an existing workflow
+will almost surely not work.
+
+#### Changes to inputs:
+ - The `GAPBRANCH` input has been replaced by `gap-version`, which accepts version numbers, branch names, or either `default` or `latest`.
+ - The input `GAP_PKGS_TO_CLONE` has been removed. This should now be done by the user in a separate step in the workflow.
+ - The input `GAP_PKGS_TO_BUILD` has been renamed to `gap-pkgs-to-build`. It can only be used to build packages distributed with GAP.
+   In addition to `IO` and `profiling`, the package `json` is now also built by default.
+ - The inputs `HPCGAP` and `ABI` have been removed, and support for both HPC-GAP and 32-bit builds has been removed.
+ - The (previously undocumented) input `CONFIGFLAGS` has been renamed to `configflags`.
+ - The input `GAP_BOOTSTRAP` has been removed. GAP will always come with all distributed packages.
+ - An input `repository` has been added, which allows building a version of GAP hosted on a repository different from `gap-system/gap`.
+
+#### Changes to functionality:
+ - There is no longer a separate branch for running this action on Windows. This action should work on Windows, assuming it is
+   preceded by version v2 or later of [setup-cygwin](https://github.com/gap-actions/setup-gap).
+ - The installation location of GAP is added to the variable `GAPROOT`, which can be used in subsequent steps in the workflow.
+ - The GAP executable is added to `PATH`, thus GAP can now always be started by calling `gap`.
+ 
 ## Contact
 Please submit bug reports, suggestions for improvements and patches via
 the [issue tracker](https://github.com/gap-actions/setup-gap/issues).

--- a/README.md
+++ b/README.md
@@ -37,11 +37,20 @@ All of the following inputs are optional.
    - default: `'io json profiling'`
 
 ### What's new in v3
-Version v3 contains many changes compared to version v2. Simply replacing `setup-gap@v2` by `setup-gap@v3` in an existing workflow
-will almost surely not work.
+Version v3 contains many changes compared to version v2. When replacing `setup-gap@v2` by `setup-gap@v3` in an existing workflow,
+you will have to change the inputs accordingly. We also recommend replacing branches be releases, e.g. `stable-v4.14` by `v4.14`.
 
 #### Changes to inputs:
- - The `GAPBRANCH` input has been replaced by `gap-version`, which accepts version numbers, branch names, or either `default` or `latest`.
+ - The `GAPBRANCH` input has been replaced by `gap-version`, which accepts the following input types:
+   - `latest`: this will use the latest release of GAP. This will **not** point to the latest pre-release if it is more recent
+     than the latest release.
+   - version numbers: e.g. `v4.14.0`, `v4.15.0-beta1`, etc. The leading `v` is optional.
+   - incomplete version numbers: e.g. `v4`, `v4.10`, etc. These will be expanded to the most recent release starting with the incomplete
+     version number, e.g. `v4.10` is equivalent to `v4.10.2`. This will **not** expand to pre-releases, and again the leading `v` is
+     optional.
+   - branch and tag names: e.g. `master`, `stable-v4.14`, etc. This will use the GAP version built from the corresponding branch or tag.
+     NB: the inputs `master`, `main` and `default` will always point at the "default branch" of the repository, i.e. the branch you are
+     presented with when navigating to `github.com/<owner>/<repo>`.
  - The input `GAP_PKGS_TO_CLONE` has been removed. This should now be done by the user in a separate step in the workflow.
  - The input `GAP_PKGS_TO_BUILD` has been renamed to `gap-pkgs-to-build`. It can only be used to build packages distributed with GAP.
    In addition to `IO` and `profiling`, the package `json` is now also built by default.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ All of the following inputs are optional.
 - `configflags`:
    - Arguments to pass to the GAP configure script.
    - default: `''`
-- `gap-pkgs-to-build`:
-   - A space-separated list of the GAP packages to build.
-   - default: `'io json profiling'`
 
 ### What's new in v3
 Version v3 contains many changes compared to version v2. When replacing `setup-gap@v2` by `setup-gap@v3` in an existing workflow,

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ All of the following inputs are optional.
 
 ### What's new in v3
 Version v3 contains many changes compared to version v2. When replacing `setup-gap@v2` by `setup-gap@v3` in an existing workflow,
-you will have to change the inputs accordingly. We also recommend replacing branches by releases, e.g. `stable-v4.14` by `v4.14`.
+you will have to change the inputs accordingly. We also recommend replacing branches by releases, e.g. `stable-4.14` by `4.14`.
 
 #### Changes to inputs:
  - The `GAPBRANCH` input has been replaced by `gap-version`, which accepts the following input types:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# setup-gap V2
+# setup-gap V3
 
 This GitHub action downloads and prepares an instance of GAP.
 It is intended to be used by the Continuous Integration (CI) action of a GAP
@@ -6,7 +6,7 @@ package, that is by an action which runs a package's test suite.
 
 ## Supported OSes
 
-This action can be run on macOS and Ubuntu.
+This action can be run on macOS, Ubuntu and Windows (when preceded by the `setup-cygwin` action).
 
 
 ## Usage
@@ -14,9 +14,8 @@ This action can be run on macOS and Ubuntu.
 The action `setup-gap` has to be called by the workflow of a GAP
 package.
 By default it
-- downloads and compiles the master branch of GAP,
-- downloads the packages distributed with GAP, and
-- compiles the packages `io` and `profiling`
+- downloads and compiles the latest release of GAP, and
+- compiles the packages `io`, `json` and `profiling`
 
 Its behaviour can be customized via the inputs below.
 
@@ -24,26 +23,20 @@ Its behaviour can be customized via the inputs below.
 
 All of the following inputs are optional.
 
-- `GAP_PKGS_TO_CLONE`:
-   - A space-separated list of the GAP packages to clone.
+- `gap-version`:
+   - The gap version or branch to build. You may specify "latest" for the latest release, or "default" for the default branch.
+   - default: `latest`
+- `repository`
+   - The GitHub repository from which to clone GAP.
+   - default: `'gap-system/gap'`
+- `configflags`:
+   - Arguments to pass to the GAP configure script.
    - default: `''`
-   - example: `'io autodoc'`
-- `GAP_PKGS_TO_BUILD`:
-   - A space-separated list of the GAP packages to build. Must include
-     `io` and `profiling`.
-   - default: `'io profiling'`
-- `GAPBRANCH`:
-   - The gap branch to clone.
-   - default: `master`
-- `HPCGAP`:
-   - Build HPC-GAP if set to `yes`.
-   - default: `no`
-- `ABI`:
-   - Set to `32` to use 32bit build flags for the package
-   - default: `''`
-- `GAP_BOOTSTRAP`
-   - Which packages to build GAP with (options: full or minimal)
-   - default: `'full'`
+- `gpk-pkgs-to-build`:
+   - A space-separated list of the GAP packages to build.
+   - default: `'io json profiling'`
+- `token`:
+   - Token to authenticate with the GitHub API. You should set this to `${{ secrets.GITHUB_TOKEN }}` in your workflow.
 
 ## Contact
 Please submit bug reports, suggestions for improvements and patches via

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ you will have to change the inputs accordingly. We also recommend replacing bran
    - branch and tag names: e.g. `master`, `stable-v4.14`, etc. This will use the GAP version built from the corresponding branch or tag.
      NB: the inputs `master`, `main` and `default` will always point at the "default branch" of the repository, i.e. the branch you are
      presented with when navigating to `github.com/<owner>/<repo>`.
- - The input `GAP_PKGS_TO_CLONE` has been removed. This should now be done by the user in a separate step in the workflow.
+ - The input `GAP_PKGS_TO_CLONE` has been removed. This should now be done by the user in a separate step in the workflow, e.g. by using
+   `git clone` or the [PackageManager](https://gap-packages.github.io/PackageManager/) package. See the Examples section below.
  - The input `GAP_PKGS_TO_BUILD` has been renamed to `gap-pkgs-to-build`. It can only be used to build packages distributed with GAP.
    In addition to `IO` and `profiling`, the package `json` is now also built by default.
  - The inputs `HPCGAP` and `ABI` have been removed, and support for both HPC-GAP and 32-bit builds has been removed.
@@ -66,7 +67,7 @@ you will have to change the inputs accordingly. We also recommend replacing bran
  - The installation location of GAP is stored in the environment variable `GAPROOT`, which can be used in subsequent steps in the workflow.
  - The GAP executable is added to `PATH`, thus GAP can now always be started by calling `gap`.
 
-### Example
+### Examples
 
 The following is a minimal example to run this action.
 
@@ -119,6 +120,16 @@ jobs:
       - uses: gap-actions/setup-gap@v3
         with:
           gap-version: ${{ matrix.gap-version }}
+      - shell: bash
+        run: |
+          # Install package via 'git clone'
+          cd $HOME/.gap/pkg
+          git clone https://github.com/gap-packages/io
+      - shell: bash
+        run: |
+          # Install packages via PackageManager
+          gap -c 'LoadPackage("PackageManager"); InstallPackage("https://github.com/gap-packages/orb"); QUIT;'
+          gap -c 'LoadPackage("PackageManager"); InstallPackage("cvec"); QUIT;'
 ```
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ you will have to change the inputs accordingly. We also recommend replacing bran
    - branch and tag names: e.g. `master`, `stable-v4.14`, etc. This will use the GAP version built from the corresponding branch or tag.
      NB: the inputs `master`, `main` and `default` will always point at the "default branch" of the repository, i.e. the branch you are
      presented with when navigating to `github.com/<owner>/<repo>`.
- - The input `GAP_PKGS_TO_CLONE` has been removed. This should now be done by the user in a separate step in the workflow, e.g. by using
-   `git clone` or the [PackageManager](https://gap-packages.github.io/PackageManager/) package. See the Examples section below.
+ - The inputs `GAP_PKGS_TO_CLONE` and `GAP_PKGS_TO_BUILD` have been removed. This should now be done by the user in a separate step in
+   the workflow, e.g. by using `git clone` or the [PackageManager](https://gap-packages.github.io/PackageManager/) package. See the
+   Examples section below.
  - The input `GAP_PKGS_TO_BUILD` has been renamed to `gap-pkgs-to-build`. It can only be used to build packages distributed with GAP.
    In addition to `IO` and `profiling`, the package `json` is now also built by default.
  - The inputs `HPCGAP` and `ABI` have been removed, and support for both HPC-GAP and 32-bit builds has been removed.
@@ -125,6 +126,10 @@ jobs:
           # Install package via 'git clone'
           cd $HOME/.gap/pkg
           git clone https://github.com/gap-packages/io
+          cd io
+          sh autogen.sh
+          ./configure --with-gaproot=$GAPROOT
+          make -j4
       - shell: bash
         run: |
           # Install packages via PackageManager

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All of the following inputs are optional.
 
 - `gap-version`:
    - The gap version or branch to build. You may specify "latest" for the latest release, or "default" for the default branch.
+     see "Changes to inputs" under "What's new in v3" for more details.
    - default: `latest`
 - `repository`
    - The GitHub repository from which to clone GAP.

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,6 @@ inputs:
     required: false
     default: 'io json profiling'
     deprecationMessage: 'This input will possibly be removed in the future, so do not rely on it too much'
-  token:
-    description: 'Token to authenticate with the GitHub API'
-    required: true
-    default: ''
 
 runs:
   using: "composite"
@@ -49,13 +45,13 @@ runs:
         if [[ -z "${{ inputs.gap-version }}" || "${{ inputs.gap-version }}" == "latest" ]] ; then
           echo "Version: latest release"
           IS_RELEASE=true
-          VERSION=$(wget --header="Authorization: Bearer ${{ inputs.token }}" -qO- "https://api.github.com/repos/${{ inputs.repository }}/releases/latest" | jq -r '.tag_name')
+          VERSION=$(wget --header="Authorization: Bearer ${{ github.token }}" -qO- "https://api.github.com/repos/${{ inputs.repository }}/releases/latest" | jq -r '.tag_name')
         elif [[ "${{ inputs.gap-version }}" =~ ^(master|main|default)$ ]] ; then
           echo "Version: default branch"
           VERSION=$(git ls-remote --symref https://github.com/${{ inputs.repository }}.git HEAD | head -n 1 | sed 's|ref: refs/heads/||; s|\tHEAD||')
         else
           echo "Checking releases"
-          GIT_RELS_JSON=$(wget --header="Authorization: Bearer ${{ inputs.token }}" -qO- "https://api.github.com/repos/${{ inputs.repository }}/releases")
+          GIT_RELS_JSON=$(wget --header="Authorization: Bearer ${{ github.token }}" -qO- "https://api.github.com/repos/${{ inputs.repository }}/releases")
           GIT_RELS=$(echo "$GIT_RELS_JSON" | jq -r '.[].tag_name' | sort -V)
           GIT_NPRS=$(echo "$GIT_RELS_JSON" | jq -r '.[] | select((.draft == false) and (.prerelease == false)) | .tag_name' | sort -V)
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
         if [[ "${{ runner.os }}" == "Linux" ]] ; then
           sudo apt-get install libgmp-dev libreadline-dev zlib1g-dev
         elif [[ "${{ runner.os }}" = "macOS" ]] ; then
-          brew install zlib autoconf && brew link zlib --force
+          brew install zlib autoconf readline && brew link zlib --force
         fi
 
     - name: "Determine GAP version"

--- a/action.yml
+++ b/action.yml
@@ -1,139 +1,154 @@
 name: 'Setup GAP for package testing'
-description: 'Download and compile CI scripts, GAP and its packages'
+description: 'Download and compile GAP and its packages'
 inputs:
-  GAP_PKGS_TO_CLONE:
-    description: 'the GAP packages to clone'
+  gap-version:
+    description: 'The GAP version or branch to build'
+    required: false
+    default: 'latest'
+  repository:
+    description: 'The GitHub repository from which to clone GAP'
+    required: false
+    default: 'gap-system/gap'
+  configflags:
+    description: 'Arguments to pass to the GAP configure script (e.g. --enable-debug)'
     required: false
     default: ''
-  GAP_PKGS_TO_BUILD:
-    description: 'the GAP packages to build'
+  gap-pkgs-to-build:
+    description: 'A space-separated list of the GAP packages to build'
     required: false
-    default: 'io profiling'
-  GAPBRANCH:
-    description: 'the gap branch to clone'
-    required: false
-    default: 'master'
-  HPCGAP:
-    description: 'build HPC-GAP if set to yes'
-    required: false
-    default: 'no'
-  ABI:
-    description: 'set to 32 to use 32bit build flags for the package'
-    required: false
+    default: 'io json profiling'
+    deprecationMessage: 'This input will possibly be removed in the future, so do not rely on it too much'
+  token:
+    description: 'Token to authenticate with the GitHub API'
+    required: true
     default: ''
-  CONFIGFLAGS:
-    description: 'arguments to pass to the GAP configure script (e.g. --enable-debug)'
-    required: false
-    default: ''
-  GAP_BOOTSTRAP:
-    description: 'make bootstrap-pkg-? (i.e. full/minimal)'
-    required: false
-    default: 'full'
-env:
-  CHERE_INVOKING: 1
+
 runs:
   using: "composite"
   steps:
-      - name: "Install dependencies"
-        run: |
-          echo "Installing dependencies"
-          if [ "${{runner.os}}" = "Linux" ]; then
-            if [ "${{inputs.ABI}}" = "32" ]; then
-              sudo dpkg --add-architecture i386
-              sudo apt-get update
-              packages=(
-                libgmp-dev:i386
-                libreadline-dev:i386
-                zlib1g-dev:i386
-                gcc-multilib
-                g++-multilib
-              )
+  
+    - name: "Install dependencies"
+      shell: bash
+      if: ${{ runner.os != 'Windows' }}
+      run: |
+        if [[ "${{ runner.os }}" == "Linux" ]] ; then
+          sudo apt-get install libgmp-dev libreadline-dev zlib1g-dev
+        elif [[ "${{ runner.os }}" = "macOS" ]] ; then
+          brew install zlib autoconf && brew link zlib --force
+        fi
+
+    - name: "Determine GAP version"
+      id: version
+      shell: bash
+      run: |
+        VERSION=""
+        IS_RELEASE=false
+
+        # Select only those releases we wish to allow, with or without pre-releases
+
+        if [[ -z "${{ inputs.gap-version }}" || "${{ inputs.gap-version }}" == "latest" ]] ; then
+          echo "Version: latest release"
+          IS_RELEASE=true
+          VERSION=$(wget --header="Authorization: Bearer ${{ inputs.token }}" -qO- "https://api.github.com/repos/${{ inputs.repository }}/releases/latest" | jq -r '.tag_name')
+        elif [[ "${{ inputs.gap-version }}" =~ ^(master|main|default)$ ]] ; then
+          echo "Version: default branch"
+          VERSION=$(git ls-remote --symref https://github.com/${{ inputs.repository }}.git HEAD | head -n 1 | sed 's|ref: refs/heads/||; s|\tHEAD||')
+        else
+          echo "Checking releases"
+          GIT_RELS_JSON=$(wget --header="Authorization: Bearer ${{ inputs.token }}" -qO- "https://api.github.com/repos/${{ inputs.repository }}/releases")
+          GIT_RELS=$(echo "$GIT_RELS_JSON" | jq -r '.[].tag_name' | sort -V)
+          GIT_NPRS=$(echo "$GIT_RELS_JSON" | jq -r '.[] | select((.draft == false) and (.prerelease == false)) | .tag_name' | sort -V)
+
+          # Add "v" in front if missing
+          REL=${{ inputs.gap-version }}
+          REL=v${REL#v}
+          
+          if echo "$GIT_RELS" | grep -qx "$REL" ; then
+            echo "Version: exact release match"
+            IS_RELEASE=true
+            VERSION=$REL
+          elif echo "$GIT_NPRS" | grep -q "^$REL\." ; then
+            echo "Version: expanded to release"
+            IS_RELEASE=true
+            VERSION=$(echo "$GIT_NPRS" | grep "^$REL\." | tail -n 1)
+          else
+            echo "Checking branches and tags"
+            if git ls-remote --heads https://github.com/${{ inputs.repository }}.git | sed 's|.*refs/heads/||' | grep -qx "${{ inputs.gap-version }}" ; then
+              echo "Version: exact branch match"
+              VERSION=${{ inputs.gap-version }}
+            elif git ls-remote --tags --refs https://github.com/${{ inputs.repository }}.git | sed 's|.*refs/tags/||' | grep -qx "${{ inputs.gap-version }}" ; then
+              echo "Version: exact tag match"
+              VERSION=${{ inputs.gap-version }}
             else
-              packages=(
-                libgmp-dev
-                libreadline-dev
-                zlib1g-dev
-              )
-            fi
-            sudo apt-get install "${packages[@]}"
-          elif [ "${{runner.os}}" = "macOS" ]; then
-            if [ "${{inputs.ABI}}" = "32" ]; then
-              echo "Can't use macOS with 32bit!"
+              echo "No release, branch or tag with name ${{ inputs.gap-version }} found"
               exit 1
             fi
-            brew install gmp zlib autoconf && brew link zlib
           fi
-        shell: bash
+        fi
 
-      - name: "Clone GAP"
-        shell: bash
-        run: git clone --depth=2 -b ${{ inputs.GAPBRANCH }} https://github.com/gap-system/gap.git $HOME/gap
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "IS_RELEASE=$IS_RELEASE" >> "$GITHUB_OUTPUT"
 
-      - name: "Build GAP"
-        shell: bash
-        env:
-          ABI: ${{ inputs.ABI }}
-        run: |
-          cd $HOME/gap
-          CONFIGFLAGS="${{ inputs.CONFIGFLAGS }}"
-          # for HPC-GAP, add suitable flags
-          if [[ ${{ inputs.HPCGAP }} = yes ]]; then
-            CONFIGFLAGS="$CONFIGFLAGS --enable-hpcgap"
-          fi
+    - name: "Set GAPROOT"
+      shell: bash
+      run: |
+        GAPROOT="$HOME/gap"
+        mkdir -p $GAPROOT
+        echo "GAPROOT=$GAPROOT" >> "$GITHUB_ENV"
+        
+    - name: "Download or clone GAP"
+      shell: bash
+      env:
+        VERSION: ${{ steps.version.outputs.VERSION }}
+        IS_RELEASE: ${{ steps.version.outputs.IS_RELEASE }}
+      run: |
+        if [[ "$IS_RELEASE" == "true" ]] ; then
+          WGET="wget -q -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
+          URL=https://github.com/${{ inputs.repository }}/releases/download/$VERSION/
+          FILE=gap-${VERSION#v}.tar.gz
+          $WGET $URL$FILE
+          tar xzf $FILE -C $GAPROOT --strip-components=1
+        else
+          git clone --branch $VERSION --depth=1 --single-branch https://github.com/${{ inputs.repository }}.git $GAPROOT
+        fi
 
-          # build GAP in a subdirectory
+    - name: "Build GAP"
+      shell: bash
+      run: |
+        cd $GAPROOT
+
+        if [ -f "autogen.sh" ] ; then
           ./autogen.sh
-          ./configure $CONFIGFLAGS
-          make -j4 V=1
+        fi
+        ./configure "${{ inputs.configflags }}"
+        make -j4 V=1
 
-          # make it available
-          ln -s $HOME/gap/gap /usr/local/bin/gap
+        # Add to PATH
+        if [ -f "$GAPROOT/gap" ] ; then
+          ln -s $GAPROOT/gap /usr/local/bin/gap
+        else
+          echo -e '#!/bin/sh\nsh '"$GAPROOT"'/bin/gap.sh "$@"\n' > /usr/local/bin/gap
+        fi
 
-      - name: "Download packages"
-        shell: bash
-        run: |
-          cd $HOME/gap
+        # Just to be sure it's executable
+        chmod +x /usr/local/bin/gap
 
-          # download packages; instruct wget to retry several times if the
-          # connection is refused, to work around intermittent failures.
-          # for older versions, set WGET, for GAP >= 4.11 set DOWNLOAD
-          WGET="wget -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
-          make bootstrap-pkg-${{ inputs.GAP_BOOTSTRAP }} DOWNLOAD="$WGET" WGET="$WGET"
+    - name: "Download GAP packages"
+      shell: bash
+      if: ${{ steps.version.outputs.IS_RELEASE == 'false' }}
+      run: |
+        cd $GAPROOT
+        WGET="wget -q -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
+        # For GAP >= 4.11 set DOWNLOAD, for older versions set WGET
+        make bootstrap-pkg-full DOWNLOAD="$WGET" WGET="$WGET"
 
-      - name: "Clone additional GAP packages"
-        shell: bash
-        run: |
-          # optionally: clone specific package versions, in case we need to test
-          # with development versions
-          cd $HOME/gap/pkg
-          for pkg in ${{ inputs.GAP_PKGS_TO_CLONE }}; do
-              # delete any existing variants of the package to avoid multiple versions
-              # from being compiled later on
-              rm -rf "${pkg##*/}"*
-              if [[ "$pkg" =~ ^http ]] ; then
-                  # looks like a full URL
-                  git clone "$pkg"
-              elif [[ "$pkg" =~ ^[^/]+/[^/]+$ ]] ; then
-                  # looks like ORG/REPO
-                  git clone https://github.com/"$pkg"
-              elif [[ "$pkg" =~ ^[^/]+$ ]] ; then
-                  # looks like just a REPO name
-                  git clone https://github.com/gap-packages/"$pkg"
-              else
-                  echo "Invalid package name or URL '$pkg' in GAP_PKGS_TO_CLONE"
-                  exit 1
-              fi
-          done
-
-      - name: "Build additional GAP packages"
-        shell:  bash
-        env:
-          ABI: ${{ inputs.ABI }}
-        run: |
-          # build some packages
-          BuildPackagesOptions="--strict"
-          shopt -s nocaseglob
-          cd $HOME/gap/pkg
-          for pkg in ${{inputs.GAP_PKGS_TO_BUILD}}; do
-              ../bin/BuildPackages.sh ${BuildPackagesOptions} $pkg*
-          done
+    - name: "Build GAP packages"
+      shell: bash
+      if: ${{ inputs.gap-pkgs-to-build  != '' }}
+      run: |
+        BuildPackagesOptions="--strict"
+        shopt -s nocaseglob
+        cd $GAPROOT/pkg
+        for pkg in ${{ inputs.gap-pkgs-to-build }}; do
+            ../bin/BuildPackages.sh ${BuildPackagesOptions} $pkg*
+        done

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,8 @@ runs:
         if [[ "${{ runner.os }}" == "Linux" ]] ; then
           sudo apt-get install libgmp-dev libreadline-dev zlib1g-dev
         elif [[ "${{ runner.os }}" = "macOS" ]] ; then
-          brew install zlib autoconf readline && brew link zlib --force
+          # Note: readline is installed by default, adding it here causes warnings in GitHub runners
+          brew install zlib autoconf && brew link zlib --force
         fi
 
     - name: "Determine GAP version"

--- a/action.yml
+++ b/action.yml
@@ -135,17 +135,17 @@ runs:
         mkdir -p /tmp/gaproot/pkg/
         ln -f -s $PWD /tmp/gaproot/pkg/
 
-        OPTS='-l "/tmp/gaproot;" --quitonbreak'
-        
         if [ -f "$GAPROOT/gap" ] ; then
           EXEC="$GAPROOT/gap"
         else
           EXEC="sh $GAPROOT/bin/gap.sh"
         fi
-        echo -e '#!/bin/bash\n'"$EXEC"' '"$OPTS"' "$@"\n' > /usr/local/bin/gap
+        echo -e '#!/bin/bash\n'"$EXEC"' -l "/tmp/gaproot;" "$@"\n' > /usr/local/bin/gap
 
         # Make it executable
         chmod +x /usr/local/bin/gap
+
+        echo 'GAP="gap --quitonbreak"' >> "$GITHUB_ENV"
 
     - name: "Download GAP packages"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -129,15 +129,22 @@ runs:
         echo "::group:: Running make"
         make -j4 V=1
 
-        echo "::group:: Adding GAP to PATH"
-        # Add to PATH
-        if [ -f "$GAPROOT/gap" ] ; then
-          ln -s $GAPROOT/gap /usr/local/bin/gap
-        else
-          echo -e '#!/bin/sh\nsh '"$GAPROOT"'/bin/gap.sh "$@"\n' > /usr/local/bin/gap
-        fi
+    - name: "Make GAP executable"
+      shell: bash
+      run: |
+        mkdir -p /tmp/gaproot/pkg/
+        ln -f -s $PWD /tmp/gaproot/pkg/
 
-        # Just to be sure it's executable
+        OPTS='-l "/tmp/gaproot;" --quitonbreak'
+        
+        if [ -f "$GAPROOT/gap" ] ; then
+          EXEC="$GAPROOT/gap"
+        else
+          EXEC="sh $GAPROOT/bin/gap.sh"
+        fi
+        echo -e '#!/bin/bash\n'"$EXEC"' '"$OPTS"' "$@"\n' > /usr/local/bin/gap
+
+        # Make it executable
         chmod +x /usr/local/bin/gap
 
     - name: "Download GAP packages"

--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,6 @@ inputs:
     description: 'Arguments to pass to the GAP configure script (e.g. --enable-debug)'
     required: false
     default: ''
-  gap-pkgs-to-build:
-    description: 'A space-separated list of the GAP packages to build'
-    required: false
-    default: 'io json profiling'
-    deprecationMessage: 'This input will possibly be removed in the future, so do not rely on it too much'
 
 runs:
   using: "composite"
@@ -155,14 +150,3 @@ runs:
         WGET="wget -q -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
         # For GAP >= 4.11 set DOWNLOAD, for older versions set WGET
         make bootstrap-pkg-full DOWNLOAD="$WGET" WGET="$WGET"
-
-    - name: "Build GAP packages"
-      shell: bash
-      if: ${{ inputs.gap-pkgs-to-build  != '' }}
-      run: |
-        BuildPackagesOptions="--strict"
-        shopt -s nocaseglob
-        cd $GAPROOT/pkg
-        for pkg in ${{ inputs.gap-pkgs-to-build }}; do
-            ../bin/BuildPackages.sh ${BuildPackagesOptions} $pkg*
-        done

--- a/action.yml
+++ b/action.yml
@@ -116,13 +116,24 @@ runs:
       shell: bash
       run: |
         cd $GAPROOT
-
+        CONFIGFLAGS="${{ inputs.configflags }}"
+        
         if [ -f "autogen.sh" ] ; then
+          echo "::group:: Running autogen"
           ./autogen.sh
         fi
-        ./configure "${{ inputs.configflags }}"
+
+        if [[ "${{ runner.os }}" = "macOS" ]] ; then
+          BP=$(brew --prefix)
+          CONFIGFLAGS="--with-gmp=$BP --with-readline=$BP/opt/readline $CONFIGFLAGS"
+        fi
+        echo "::group:: Running configure with flags $CONFIGFLAGS"
+        ./configure $CONFIGFLAGS
+
+        echo "::group:: Running make"
         make -j4 V=1
 
+        echo "::group:: Adding GAP to PATH"
         # Add to PATH
         if [ -f "$GAPROOT/gap" ] ; then
           ln -s $GAPROOT/gap /usr/local/bin/gap


### PR DESCRIPTION
This PR aims to tackle a few of the issues in this repo:
- https://github.com/gap-actions/setup-gap/issues/24
  The input `gap-version` can now take the following inputs:
   - `latest`, which will build the latest release of GAP using the release tarball;
   - `default` or `master` or `main`, which will build the default branch of GAP using `git clone`;
   - `branchname`, which will build the corresponding branch using `git clone`;
   - `tagname`, which will build the corresponding tag using `git clone`;
   - `X.Y.Z` or `vX.Y.Z`, which will build the corresponding release of GAP (*including* pre-releases), using the release tarball;
   - `X` or `vX` or `X.Y` or `vX.Y`, which will build the most recent release of GAP whose version is of the form `X.Y.Z` (*excluding* pre-releases), using the release tarball.
- https://github.com/gap-actions/setup-gap/issues/31
  The action now adds the variable `GAPROOT` to `GITHUB_ENV`, so it can be picked up by other steps/actions in a workflow following this action.
  At the same time, it is also ensured that GAP is available from `PATH` by calling `gap`.
- https://github.com/gap-actions/setup-gap/issues/36
  The `repository` input allows downloading gap from other repositories. 
- https://github.com/gap-actions/setup-gap/issues/45
  Support for 32-bit is completely dropped.
- https://github.com/gap-actions/setup-gap/issues/47
   - The input `GAP_PKGS_TO_CLONE` has been removed completely. The input `GAP_PKGS_TO_BUILD` was renamed to `gap-pkgs-to-build` and is now intended only to build the packages that come with GAP (either from the release tarball or from running `make bootstrap-pkg-full`).
   - The `HPCGAP` input has been removed
   - `io`and `profiling` have not been removed from the default `gap-pkgs-to-build` input, and `json` has in fact been added. This is a temporary measure, the plan is to let the actions using these packages take care of this themselves in the future.

Other noteworthy changes:
- The `GAP_BOOTSTRAP` input has been removed. It would have done nothing when GAP was built from a release tarball anyway, and setting this to `minimal` was rarely done as most workflows/actions/tests required at least some package not found in the minimal setup.
- The CI for this action has been expanded quite a bit.
- If Cygwin was setup via https://github.com/gap-actions/setup-cygwin/pull/14, this action no longer needs a separate `cygwin` branch (see #18).
- An input `token` has been added, which should be supplied with `${{ secrets.GITHUB_TOKEN }}`. This is used for authenticating with the GitHub API, which is very strongly rate-limited for unauthenticated users.

Remarks / Questions:
- Should `setup-cygwin` be a part of this action? Currently, to use this action on Windows, is needs to be preceded by something like 
  ```
  - name: "Setup Cygwin"
    if: ${{ matrix.os == 'windows-latest' }}
    uses: stertooy/setup-cygwin@official-action-and-batch
  ```
  That works just fine, but we could also do this as part of this action instead.

- It is possible to build a particular PR (see https://github.com/gap-actions/setup-gap/issues/36) using the `repository` and `gap-version` inputs. But I could also allow `gap-version` to take an input of the form `#XYZW` to do this automatically. E.g. given the inputs `repository: gap-system/gap` and `gap-version: #5956`, the action would use the GitHub API to decide that it should build GAP using branch `mh/proto-rereading` from repository `fingolfin/gap`. Should I add such mechanism to this PR?

- This action uses the GitHub API to get releases... so it only works with releases available on GitHub. In practice, this is v4.10.0 and later.

- It appears that GAP versions < 4.13 do not work properly on the `macos-latest` runner. In particular:
  - Versions < 4.13 cannot find the system's GMP and will therefore always attempt to install the GMP version bundled with GAP.
  - Version 4.12 will succeed in installing with the bundled GMP, but GAP will often (though not always) crash when started. This always happens at
    ```
    Syntax warning: Unbound global variable in /Users/runner/gap/lib/primality.gi:\
    515
      Np:=(N-1)/p;
      ^^
    ```
    but the final error varies (segfault, <list> must be a list, ...).
  - Versions < 4.12 cannot even install the bundled GMP, as they try to configure it with `ABI=64` causing
    ```
    configure: error: ABI=64 is not among the following valid choices: 32
    ```
  I don't think it's worth looking into this since it only happens with old versions of GAP, but it might be prudent to warn users that we do not support the combination of gap <4.13 and MacOS runners?

- Installing the bundled GMP on Cygwin sometimes fails, e.g. with
  ```
  make[4]: Entering directory '/home/runneradmin/gap/extern/build/gmp/demos/calc'
  test -f calc.c || /bin/sh /home/runneradmin/gap/extern/gmp/ylwrap /home/runneradmin/gap/extern/gmp/demos/calc/calc.y y.tab.c calc.c y.tab.h `echo calc.c | sed -e s/cc$/hh/ -e s/cpp$/hpp/ -e s/cxx$/hxx/ -e s/c++$/h++/ -e s/c$/h/` y.output calc.output -- yacc -d 
  /home/runneradmin/gap/extern/gmp/ylwrap: line 176: yacc: command not found
  make[4]: *** [Makefile:456: calc.c] Error 127
  ```
  Again, I'm not sure whether it's worth looking into this any further, and we could just decide that Cygwin + `--with-gmp=builtin` is not supported?

- It would probably be a good idea for other actions to use the `GAPROOT` variable and/or run `gap` in the command line instead of `$HOME/gap/gap`. In particular, these other actions could then be used with a docker container that also adds `gap` to `PATH` and sets the `GAPROOT` variable.

As a "proof-of-concept": [this workflow run](https://github.com/stertooy/run-pkg-tests/actions/runs/14811829398) uses the `run-pkg-tests` workflow, but with this PR instead of the usual `setup-gap` and with https://github.com/gap-actions/setup-cygwin/pull/14 instead of the usual `setup-cygwin`.