### PR TITLE
Use releases.json file instead of GitHub API

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,47 +34,49 @@ runs:
       shell: bash
       run: |
         VERSION=""
-        IS_RELEASE=false
+        IS_RELEASE=true
 
-        # Select only those releases we wish to allow, with or without pre-releases
-
-        if [[ -z "${{ inputs.gap-version }}" || "${{ inputs.gap-version }}" == "latest" ]] ; then
-          echo "Version: latest release"
-          IS_RELEASE=true
-          VERSION=$(wget --header="Authorization: Bearer ${{ github.token }}" -qO- "https://api.github.com/repos/${{ inputs.repository }}/releases/latest" | jq -r '.tag_name')
-        elif [[ "${{ inputs.gap-version }}" =~ ^(master|main|default)$ ]] ; then
-          echo "Version: default branch"
-          VERSION=$(git ls-remote --symref https://github.com/${{ inputs.repository }}.git HEAD | head -n 1 | sed 's|ref: refs/heads/||; s|\tHEAD||')
-        else
-          echo "Checking releases"
-          GIT_RELS_JSON=$(wget --header="Authorization: Bearer ${{ github.token }}" -qO- "https://api.github.com/repos/${{ inputs.repository }}/releases")
-          GIT_RELS=$(echo "$GIT_RELS_JSON" | jq -r '.[].tag_name' | sort -V)
-          GIT_NPRS=$(echo "$GIT_RELS_JSON" | jq -r '.[] | select((.draft == false) and (.prerelease == false)) | .tag_name' | sort -V)
-
-          # Add "v" in front if missing
-          REL=${{ inputs.gap-version }}
-          REL=v${REL#v}
-          
-          if echo "$GIT_RELS" | grep -qx "$REL" ; then
-            echo "Version: exact release match"
-            IS_RELEASE=true
-            VERSION=$REL
-          elif echo "$GIT_NPRS" | grep -q "^$REL\." ; then
-            echo "Version: expanded to release"
-            IS_RELEASE=true
-            VERSION=$(echo "$GIT_NPRS" | grep "^$REL\." | tail -n 1)
+        # We only check for releases in the official repository
+        if [[ "${{ inputs.repository }}" == "gap-system/gap" ]] ; then
+          wget -q -O $RUNNER_TEMP/gap_releases.json "https://raw.githubusercontent.com/Joseph-Edwards/GapWWW/refs/heads/add-json/_data/gap_releases.json" 
+          if [[ "${{ inputs.gap-version }}" == "latest" ]] ; then
+            echo "Version: latest release"
+            VERSION=$(cat $RUNNER_TEMP/gap_releases.json | jq -r '.[] | select(.isLatest == true) | .tagName ')
           else
-            echo "Checking branches and tags"
-            if git ls-remote --heads https://github.com/${{ inputs.repository }}.git | sed 's|.*refs/heads/||' | grep -qx "${{ inputs.gap-version }}" ; then
-              echo "Version: exact branch match"
-              VERSION=${{ inputs.gap-version }}
-            elif git ls-remote --tags --refs https://github.com/${{ inputs.repository }}.git | sed 's|.*refs/tags/||' | grep -qx "${{ inputs.gap-version }}" ; then
-              echo "Version: exact tag match"
-              VERSION=${{ inputs.gap-version }}
-            else
-              echo "No release, branch or tag with name ${{ inputs.gap-version }} found"
-              exit 1
+            echo "Checking releases"
+            GIT_RELS=$(cat $RUNNER_TEMP/gap_releases.json | jq -r '.[].tagName' | sort -V)
+            GIT_NPRS=$(cat $RUNNER_TEMP/gap_releases.json | jq -r '.[] | select(.isPrerelease == false) | .tagName' | sort -V)
+
+            # Add "v" in front if missing
+            REL=${{ inputs.gap-version }}
+            REL=v${REL#v}
+
+            if echo "$GIT_RELS" | grep -qx "$REL" ; then
+              echo "Version: exact release match"
+              VERSION=$REL
+            elif echo "$GIT_NPRS" | grep -q "^$REL\." ; then
+              echo "Version: expanded to release"
+              VERSION=$(echo "$GIT_NPRS" | grep "^$REL\." | tail -n 1)
             fi
+          fi
+        fi
+
+        # If we use a different repo or didn't match a release, we try branches and tags instead
+        if [[ -z "$VERSION" ]] ; then
+          IS_RELEASE=false
+          # Use the repository's default branch, or autocorrect to the default one if "master" or "main" was given
+          if [[ "${{ inputs.gap-version }}" =~ ^(master|main|default)$ ]] ; then
+            echo "Version: default branch"
+            VERSION=$(git ls-remote --symref https://github.com/${{ inputs.repository }}.git HEAD | head -n 1 | sed 's|ref: refs/heads/||; s|\tHEAD||')
+          elif git ls-remote --heads https://github.com/${{ inputs.repository }}.git | sed 's|.*refs/heads/||' | grep -qx "${{ inputs.gap-version }}" ; then
+            echo "Version: exact branch match"
+            VERSION=${{ inputs.gap-version }}
+          elif git ls-remote --tags --refs https://github.com/${{ inputs.repository }}.git | sed 's|.*refs/tags/||' | grep -qx "${{ inputs.gap-version }}" ; then
+            echo "Version: exact tag match"
+            VERSION=${{ inputs.gap-version }}
+          else
+            echo "No release, branch or tag with name ${{ inputs.gap-version }} found"
+            exit 1
           fi
         fi
 
@@ -95,11 +97,23 @@ runs:
         IS_RELEASE: ${{ steps.version.outputs.IS_RELEASE }}
       run: |
         if [[ "$IS_RELEASE" == "true" ]] ; then
-          WGET="wget -q -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
-          URL=https://github.com/${{ inputs.repository }}/releases/download/$VERSION/
-          FILE=gap-${VERSION#v}.tar.gz
-          $WGET $URL$FILE
-          tar xzf $FILE -C $GAPROOT --strip-components=1
+          WGET="wget -q -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused -O gap.tar.gz"
+          URL=$(cat $RUNNER_TEMP/gap_releases.json | jq -r --arg VERSION "$VERSION" '.[] | select(.tagName == $VERSION) | .url ')
+          SHA=$(cat $RUNNER_TEMP/gap_releases.json | jq -r --arg VERSION "$VERSION" '.[] | select(.tagName == $VERSION) | .sha256 ')
+          # Download archive
+          $WGET $URL
+          # Recalculate checksum
+          CHK=$(shasum -a 256 gap.tar.gz | awk '{print $1}')
+          # Remove leading backslash if present, this can happen on Cygwin
+          CHK=${CHK#\\}
+          # Compare checksums
+          if [[ "$SHA" != "$CHK" ]] ; then
+            echo "Checksum is wrong!"
+            exit 1
+          fi
+          # Extract archive
+          tar xzf gap.tar.gz -C $GAPROOT --strip-components=1
+          rm gap.tar.gz
         else
           git clone --branch $VERSION --depth=1 --single-branch https://github.com/${{ inputs.repository }}.git $GAPROOT
         fi

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
 
         # We only check for releases in the official repository
         if [[ "${{ inputs.repository }}" == "gap-system/gap" ]] ; then
-          wget -q -O $RUNNER_TEMP/gap_releases.json "https://raw.githubusercontent.com/gap-system/GapWWW/refs/heads/master/_data/gap_releases.json" 
+          wget -q -O $RUNNER_TEMP/gap_releases.json https://www.gap-system.org/releases.json
           if [[ "${{ inputs.gap-version }}" == "latest" ]] ; then
             echo "Version: latest release"
             VERSION=$(cat $RUNNER_TEMP/gap_releases.json | jq -r '.[] | select(.isLatest == true) | .tagName ')

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
 
         # We only check for releases in the official repository
         if [[ "${{ inputs.repository }}" == "gap-system/gap" ]] ; then
-          wget -q -O $RUNNER_TEMP/gap_releases.json "https://raw.githubusercontent.com/Joseph-Edwards/GapWWW/refs/heads/add-json/_data/gap_releases.json" 
+          wget -q -O $RUNNER_TEMP/gap_releases.json "https://raw.githubusercontent.com/gap-system/GapWWW/refs/heads/master/_data/gap_releases.json" 
           if [[ "${{ inputs.gap-version }}" == "latest" ]] ; then
             echo "Version: latest release"
             VERSION=$(cat $RUNNER_TEMP/gap_releases.json | jq -r '.[] | select(.isLatest == true) | .tagName ')


### PR DESCRIPTION
Requires https://github.com/gap-system/GapWWW/pull/384 to be merged, the corresponding URL in action.yml needs to then be updated.