### PR TITLE
Fix the $GAP variable, and properly test it

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Setup Cygwin"
         if: ${{ matrix.os == 'windows-latest' }}
         uses: gap-actions/setup-cygwin@v2
-        
+
       - name: "Setup GAP"
         uses: ./
         with:
@@ -56,10 +56,9 @@ jobs:
           gap -A <<GAPINPUT
             quit;
           GAPINPUT
-
-      - name: "Check ENV for GAPROOT and GAP variables"
-        shell: bash
-        run: |
-          if [[ -z "$GAPROOT" || -z "$GAP" ]] ; then
-            exit 1
-          fi
+          $GAP -A <<GAPINPUT
+            quit;
+          GAPINPUT
+          $GAPROOT/gap -A <<GAPINPUT
+            quit;
+          GAPINPUT

--- a/action.yml
+++ b/action.yml
@@ -155,7 +155,7 @@ runs:
         # Make it executable
         chmod +x /usr/local/bin/gap
 
-        echo 'GAP="gap --quitonbreak"' >> "$GITHUB_ENV"
+        echo "GAP=gap --quitonbreak" >> "$GITHUB_ENV"
 
     - name: "Download GAP packages"
       shell: bash


### PR DESCRIPTION
Previously I had put `GAP="gap --quitonbreak"` in `$GITHUB_ENV`. But this doesn't work like a normal terminal session, and the `GAP` variable was actually unusable.

This should fix it. Also, instead of just checking if `GAP` and `GAPROOT` are non-empty, the CI tests now check if they can be used to run GAP.