### PR TITLE
Workaround: build IO package again

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -165,3 +165,8 @@ runs:
         WGET="wget -q -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
         # For GAP >= 4.11 set DOWNLOAD, for older versions set WGET
         make bootstrap-pkg-full DOWNLOAD="$WGET" WGET="$WGET"
+
+        # FIXME/HACK: for the time being, build the io package, until we have
+        # dealt with <https://github.com/gap-packages/RepnDecomp/issues/23>
+        cd pkg
+        ../bin/BuildPackages.sh --strict io*


### PR DESCRIPTION
Deals with https://github.com/gap-packages/RepnDecomp/issues/23
and other similar issues that were hidden by io always being
loadable. Once all of those are resolved, we can drop this hack.
