### PR TITLE
Adjust workaround to build IO package in all cases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -166,7 +166,10 @@ runs:
         # For GAP >= 4.11 set DOWNLOAD, for older versions set WGET
         make bootstrap-pkg-full DOWNLOAD="$WGET" WGET="$WGET"
 
-        # FIXME/HACK: for the time being, build the io package, until we have
-        # dealt with <https://github.com/gap-packages/RepnDecomp/issues/23>
-        cd pkg
+    # FIXME/HACK: for the time being, build the io package, until we have
+    # dealt with <https://github.com/gap-packages/RepnDecomp/issues/23>
+    - name: "Build the IO package"
+      shell: bash
+      run: |
+        cd ${GAPROOT}/pkg
         ../bin/BuildPackages.sh --strict io*


### PR DESCRIPTION
With the change in #59, IO was only being built if GAP was not a released version. But for our hack, we want IO building in all cases.