### PR TITLE
Remove hack which builds the IO package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -165,11 +165,3 @@ runs:
         WGET="wget -q -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
         # For GAP >= 4.11 set DOWNLOAD, for older versions set WGET
         make bootstrap-pkg-full DOWNLOAD="$WGET" WGET="$WGET"
-
-    # FIXME/HACK: for the time being, build the io package, until we have
-    # dealt with <https://github.com/gap-packages/RepnDecomp/issues/23>
-    - name: "Build the IO package"
-      shell: bash
-      run: |
-        cd ${GAPROOT}/pkg
-        ../bin/BuildPackages.sh --strict io*


### PR DESCRIPTION
This was/is a workaround for issues in RepnDecomp and HeLP and maybe other packages that went undetected so far.


Should not be merged until fixes for those issues are in releases of those packages:

- [x] RepnDecomp
  - issue: https://github.com/gap-packages/RepnDecomp/issues/23
  - PR: https://github.com/gap-packages/RepnDecomp/issues/24
  - not yet fixed in a release
- [x]  HeLP
  - issue: https://github.com/gap-packages/HeLP/issues/22
  - no PR fixing this available yet
  - not yet fixed in a release
