### PR TITLE
Don't run autogen.sh if configure already exists

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -181,7 +181,7 @@ runs:
         cd $GAPROOT
         CONFIGFLAGS="${{ inputs.configflags }}"
 
-        if [ -f "autogen.sh" ] ; then
+        if [ ! -x "configure" ] ; then
           echo "::group:: Running autogen"
           ./autogen.sh
         fi


### PR DESCRIPTION
That should mainly affect GAP release tarballs.

Should fix #73 but will have to be tested

CC @james-d-mitchell 