### PR TITLE
Don't build IO

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -225,11 +225,3 @@ runs:
         WGET="wget -q -N --no-check-certificate --tries=5 --waitretry=5 --retry-connrefused"
         # For GAP >= 4.11 set DOWNLOAD, for older versions set WGET
         make bootstrap-pkg-full DOWNLOAD="$WGET" WGET="$WGET"
-
-    # FIXME/HACK: for the time being, build the io package, until we have
-    # dealt with <https://github.com/gap-packages/RepnDecomp/issues/23>
-    - name: "Build the IO package"
-      shell: bash
-      run: |
-        cd ${GAPROOT}/pkg
-        ../bin/BuildPackages.sh --strict io*


### PR DESCRIPTION
We've already stopped building IO a few times, but had to revert it every time (see e.g. https://github.com/gap-actions/setup-gap/commit/1bd4673c19a5bb87d4b33189db962305bc0bce7a).

With the release of `build-pkg@v3`, building IO (if needed) should become the responsability of that action. This can be done by adding `IO` either to the `Dependencies.TestPackages` component in `PackageInfo.g`, or to the `extra-pkgs` input of the action.

(Making this a draft PR for now since I'm not sure if we want to merge this right away)