### PR TITLE
Make CI more standard, also test GAP 4.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,33 +9,43 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.gap-version }} on ${{ matrix.os }} with ${{ matrix.configflags }}
+    name: ${{ matrix.gap-version }} on ${{ matrix.os }} with ${{ !matrix.configflags && 'system GMP' || 'builtin GMP'}}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         gap-version:
-          - v4.10
-          - v4.11.1
-          - stable-4.12
-          - v4.13.0-alpha2
-          - 4.15.0-beta1
-          - 4
-          - latest
-          - devel
-          - v4.16dev
+          - 'devel'
+          - '4.15'
+          - '4.14'
+          - '4.13'
+          - '4.12'
+          - '4.11'
+          - '4.10'
+          - '4.9'
         configflags: ['', '--with-gmp=builtin']
         exclude:
           - os: windows-latest
             configflags: '--with-gmp=builtin'
           - os: macos-latest
-            gap-version: stable-4.12
-          - os: macos-latest
-            gap-version: v4.10
-          - os: macos-latest
-            gap-version: v4.11.1
             configflags: '--with-gmp=builtin'
+        include:
+          - os: ubuntu-latest
+            gap-version: latest
+            configflags: ''
+          - os: ubuntu-latest
+            gap-version: stable-4.15
+            configflags: ''
+          - os: ubuntu-latest
+            gap-version: v4.11.1
+            configflags: ''
+          - os: ubuntu-latest
+            gap-version: 4
+            configflags: ''
+          - os: ubuntu-latest
+            gap-version: 4.15.0-beta1
+            configflags: ''
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
- Also test GAP 4.9
- Ensure we test this action on all GAP versions and OS's we expect to see in actual workflows
- Still keep some of the more "exotic" gap-versions in the CI, but don't test those in too many configurations