### PR TITLE
Add `minimal` as a possible input for `gap-version`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,9 @@ jobs:
             configflags: '--with-gmp=builtin'
         include:
           - os: ubuntu-latest
+            gap-version: minimal
+            configflags: ''
+          - os: ubuntu-latest
             gap-version: latest
             configflags: ''
           - os: ubuntu-latest
@@ -49,15 +52,23 @@ jobs:
             configflags: ''
 
     steps:
+      - name: "Clone the Example package"
+        uses: actions/checkout@v7
+        if: ${{ matrix.gap-version == 'minimal' }}
+        with:
+          repository: gap-packages/example
+
       - name: "Checkout"
         uses: actions/checkout@v7
+        with:
+          path: this-action/
 
       - name: "Setup Cygwin"
         if: ${{ matrix.os == 'windows-latest' }}
         uses: gap-actions/setup-cygwin@v2
 
       - name: "Setup GAP"
-        uses: ./
+        uses: ./this-action/
         with:
           gap-version: ${{ matrix.gap-version }}
           configflags: ${{ matrix.configflags }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Its behaviour can be customized via the inputs below.
 All of the following inputs are optional.
 
 - `gap-version`:
-   - The gap version or branch to build. You may specify "latest" for the latest release, or "devel" for the development version.
+   - The gap version or branch to build. You may specify "latest" for the latest release, "devel" for the development version,
+     or "minimal" for the minimal version supported by the GAP package in the current directory.
      See "Changes to inputs" under "What's new in v3" for more details.
    - default: `latest`
 - `repository`
@@ -40,6 +41,8 @@ you will have to change the inputs accordingly. We also recommend replacing bran
  - The `GAPBRANCH` input has been replaced by `gap-version`, which accepts the following input types:
    - `latest`: this will use the latest release of GAP. This will **not** point to the latest pre-release if it is more recent
      than the latest release.
+   - `minimal`: this will use oldest version of GAP that is supported by both the GAP package in the current directory, and this
+     action.
    - version numbers: e.g. `v4.14.0`, `v4.15.0-beta1`, etc. The leading `v` is optional, the oldest available release is `v4.10.0`.
    - incomplete version numbers: e.g. `v4`, `v4.10`, etc. These will be expanded to the most recent release starting with the incomplete
      version number, e.g. `v4.10` is equivalent to `v4.10.2`. This will **not** expand to pre-releases, and again the leading `v` is

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ you will have to change the inputs accordingly. We also recommend replacing bran
    - `latest`: this will use the latest release of GAP. This will **not** point to the latest pre-release if it is more recent
      than the latest release.
    - `minimal`: this will use oldest version of GAP that is supported by both the GAP package in the current directory, and this
-     action.
+     action (which currently means GAP 4.9).
    - version numbers: e.g. `v4.14.0`, `v4.15.0-beta1`, etc. The leading `v` is optional, the oldest available release is `v4.10.0`.
    - incomplete version numbers: e.g. `v4`, `v4.10`, etc. These will be expanded to the most recent release starting with the incomplete
      version number, e.g. `v4.10` is equivalent to `v4.10.2`. This will **not** expand to pre-releases, and again the leading `v` is

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,10 @@ runs:
               # work, in practice it does work quite well)
               REGEX="GAP[[:space:]]*:=[[:space:]]*\"([^\"]*)\""
 
-              if [[ $(cat PackageInfo.g) =~ ${REGEX} ]]; then
+              if [[ ! -f "PackageInfo.g" ]]; then
+                echo "::error::Could not find PackageInfo.g."
+                exit 1
+              elif [[ $(cat PackageInfo.g) =~ ${REGEX} ]]; then
                 # Get from capture group in regex
                 PKG_VER="${BASH_REMATCH[1]}"
                 echo "Version: PackageInfo.g contains \"${PKG_VER}\""
@@ -125,9 +128,8 @@ runs:
                 REL=$(printf '%s\n' "${PKG_VER}" "${OLDEST_VER}" | sort -V | tail -n1)
                 echo "Version: turned \"${PKG_VER}\" into \"${REL}\""
               else
-                # Hard-coded minimal version supported by this action
-                REL="${OLDEST_VER}"
-                echo "Version: could not find in PackageInfo.g, defaulting to \"${REL}\""
+                echo "::error::Could not extract minimal supported version from PackageInfo.g."
+                exit 1
               fi
             fi
 

--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,9 @@ runs:
 
             REL=${{ inputs.gap-version }}
             if [[ "$REL" == "minimal" ]]; then
-              # Get from PackageInfo.g
+              # Attempt to extract the minimal support GAP version from
+              # PackageInfo.g via a regex (while in theory this can not always
+              # work, in practice it does work quite well)
               REGEX="GAP[[:space:]]*:=[[:space:]]*\"([^\"]*)\""
 
               if [[ $(cat PackageInfo.g) =~ ${REGEX} ]]; then
@@ -119,7 +121,7 @@ runs:
                 # Remove leading stuff if present
                 PKG_VER=${PKG_VER##*[>= ]}
 
-                # Replace by oldest supported version if necessary
+                # Ensure the extracted version is not below the oldest GAP version supported by this GAP acttion
                 REL=$(printf '%s\n' "${PKG_VER}" "${OLDEST_VER}" | sort -V | tail -n1)
                 echo "Version: turned \"${PKG_VER}\" into \"${REL}\""
               else

--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
                 PKG_VER="${BASH_REMATCH[1]}"
                 echo "Version: PackageInfo.g contains \"${PKG_VER}\""
 
-                # Remove leading stuff is present
+                # Remove leading stuff if present
                 PKG_VER=${PKG_VER##*[>= ]}
 
                 # Replace by oldest supported version if necessary

--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,8 @@ runs:
     - name: "Determine GAP version"
       id: version
       shell: bash
+      env:
+        OLDEST_VER: "4.9"
       run: |
         VERSION=""
         IS_RELEASE=true
@@ -104,8 +106,30 @@ runs:
             GIT_RELS=$(cat $RUNNER_TEMP/gap_releases.json | jq -r '.[].tagName' | sort -V)
             GIT_NPRS=$(cat $RUNNER_TEMP/gap_releases.json | jq -r '.[] | select(.isPrerelease == false) | .tagName' | sort -V)
 
-            # Add "v" in front if missing
             REL=${{ inputs.gap-version }}
+            if [[ "$REL" == "minimal" ]]; then
+              # Get from PackageInfo.g
+              REGEX="GAP[[:space:]]*:=[[:space:]]*\"([^\"]*)\""
+
+              if [[ $(cat PackageInfo.g) =~ ${REGEX} ]]; then
+                # Get from capture group in regex
+                PKG_VER="${BASH_REMATCH[1]}"
+                echo "Version: PackageInfo.g contains \"${PKG_VER}\""
+
+                # Remove leading stuff is present
+                PKG_VER=${PKG_VER##*[>= ]}
+
+                # Replace by oldest supported version if necessary
+                REL=$(printf '%s\n' "${PKG_VER}" "${OLDEST_VER}" | sort -V | tail -n1)
+                echo "Version: turned \"${PKG_VER}\" into \"${REL}\""
+              else
+                # Hard-coded minimal version supported by this action
+                REL="${OLDEST_VER}"
+                echo "Version: could not find in PackageInfo.g, defaulting to \"${REL}\""
+              fi
+            fi
+
+            # Ensure a "v" is in front
             REL=v${REL#v}
 
             if echo "$GIT_RELS" | grep -qx "$REL" ; then


### PR DESCRIPTION
If `gap-version` is given the value `minimal`, this will attempt to extract the `Dependencies.GAP` value from `PackageInfo.g` and use that as the GAP version to be built.

If no version could be extracted from `PackageInfo.g`, or if the extracted version is older than this action supports, we use the oldest version supported by this action instead.

A small caveat: many packages declare something like "4.10" as minimal version, by which they probably mean "4.10.0". But by default this action expands minor versions to the newest one instead of the oldest, so "4.10" becomes "4.10.2" instead of "4.10.0".